### PR TITLE
Made dependency versions specific for future stability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Marc Farra <marcfarra@gmail.com>"]
 
 [dependencies]
-num = "*"
-image = "*"
-piston = "*"
+num = "0.1.31"
+image = "0.7.0"
+piston = "0.18.0"
 piston_window = "0.38.0"


### PR DESCRIPTION
The current repository doesn't compile on my machine, propably because the dependencies developed further without backwards compatibility. I searched for the newest dependecy versions at the time when you created the repository and made them explicit. Now it compiles on my machine and should be stable even in the future.

Thanks for the nice example.
